### PR TITLE
Watcher now emits `Write` event for size only change

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -686,7 +686,7 @@ func (w *Watcher) pollEvents(files map[string]os.FileInfo, evt chan Event,
 			creates[path] = info
 			continue
 		}
-		if oldInfo.ModTime() != info.ModTime() {
+		if oldInfo.ModTime() != info.ModTime() || oldInfo.Size() != info.Size() {
 			select {
 			case <-cancel:
 				return


### PR DESCRIPTION
On some file systems, multiple changes to the same file within
the file system's mod time resolution would be missed. This
issue can be ameliorated by triggering `Write` events if a
size change is detected, even if no corresponding mod time
change occurs.

Changes to the file content without a change to the size or
mod time will still go unnoticed.